### PR TITLE
Add top padding to the session items so they're not squeezed against the separator line

### DIFF
--- a/main.css
+++ b/main.css
@@ -68,7 +68,8 @@ body{
 }
 
 .sessions li{
-  margin-bottom:10px;
+  padding-top: 10px;
+  margin-bottom: 10px;
   list-style:none;
   font-size:1.4em;
   border-top:2px solid #88e93c;


### PR DESCRIPTION
Before:

![image](https://cloud.githubusercontent.com/assets/516559/18406066/0462d5c6-76ad-11e6-8310-8ac27678dd57.png)

After:

![image](https://cloud.githubusercontent.com/assets/516559/18406069/0be53442-76ad-11e6-901b-235d5d50c80a.png)
